### PR TITLE
Add Python 3 support, tox.ini, and some classifier tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist/*
 *#
 *.pyc
 scratch.py
+.tox

--- a/MANIFEST
+++ b/MANIFEST
@@ -2,3 +2,7 @@
 setup.py
 statestyle/__init__.py
 statestyle/data.py
+statestyle/__pycache__/__init__.cpython-32.pyc
+statestyle/__pycache__/__init__.cpython-33.pyc
+statestyle/__pycache__/data.cpython-32.pyc
+statestyle/__pycache__/data.cpython-33.pyc

--- a/setup.py
+++ b/setup.py
@@ -70,13 +70,26 @@ if len(sys.argv) > 1 and sys.argv[1] == 'bdist_wininst':
     for file_info in data_files:
         file_info[0] = '\\PURELIB\\%s' % file_info[0]
 
-setup(name='latimes-statestyle',
-      version='0.1.2',
-      description='Standardizes data about U.S. states',
-      author='Ben Welsh',
-      author_email='ben.welsh@latimes.com',
-      packages=packages,
-      cmdclass = cmdclasses,
-      data_files=data_files,
-      include_package_data=True,
-     )
+setup(
+    name='latimes-statestyle',
+    version='0.1.2',
+    description='Standardizes data about U.S. states',
+    author='Ben Welsh',
+    author_email='ben.welsh@latimes.com',
+    packages=packages,
+    cmdclass=cmdclasses,
+    data_files=data_files,
+    include_package_data=True,
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.5',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.1',
+        'Programming Language :: Python :: 3.2',
+        'Programming Language :: Python :: 3.3',
+    ],
+)

--- a/statestyle/__init__.py
+++ b/statestyle/__init__.py
@@ -1,4 +1,4 @@
-from data import CROSSWALK
+from .data import CROSSWALK
 
 
 def get(value):
@@ -15,7 +15,7 @@ def get(value):
     except ValueError:
         pass
     # Clean up any strings
-    if isinstance(value, basestring):
+    if _is_string(value):
         value = value.strip().lower()
     # Convert numbers back to strings
     elif isinstance(value, (int, float)):
@@ -46,3 +46,14 @@ class State(object):
     
     def __unicode__(self):
         return self.name
+
+
+def _is_string(possible_string):
+    """
+    Checks if an object is a string.
+    Works with Python2 and Python3.
+    """
+    try:
+        return isinstance(possible_string, basestring)
+    except NameError:
+        return isinstance(possible_string, str)

--- a/test.py
+++ b/test.py
@@ -5,10 +5,10 @@ import statestyle
 
 
 class BaseTest(unittest.TestCase):
-    
+
     def setUp(self):
-        self.good_postals = ['CA', 'IA', 'dc', 'iL ',]
-        self.bad_postals = ['XX', 'xx', 'Xx',]
+        self.good_postals = ['CA', 'IA', 'dc', 'iL ']
+        self.bad_postals = ['XX', 'xx', 'Xx']
         self.good_names = ['California', 'Iowa', 'district of columbia', 'ILLINOIS']
         self.bad_names = ['Los Angeles', 'Cedar Rapids', 'Shaw', 'CHICAGO']
         self.good_fips = ['6', '19', 11, 17, '08']
@@ -16,8 +16,9 @@ class BaseTest(unittest.TestCase):
         self.good_ap = ['Calif.', 'Iowa', 'd.c.', 'ILL.']
         self.bad_ap = ['Cali', 'iow', 'CD', 'ILLI']
 
+
 class GetTest(BaseTest):
-    
+
     def test_attr(self):
         obj = statestyle.get("CA")
         self.assertEqual(obj.postal, 'CA')
@@ -26,22 +27,30 @@ class GetTest(BaseTest):
         self.assertEqual(obj.type, 'state')
         self.assertEqual(obj.ap, 'Calif.')
         self.assertEqual(obj.stateface, 'E')
-    
+
     def test_postals(self):
-        [statestyle.get(i) for i in self.good_postals]
-        [self.assertRaises(ValueError, statestyle.get, i) for i in self.bad_postals]
-    
+        for i in self.good_postals:
+            statestyle.get(i)
+        for i in self.bad_postals:
+            self.assertRaises(ValueError, statestyle.get, i)
+
     def test_names(self):
-        [statestyle.get(i) for i in self.good_names]
-        [self.assertRaises(ValueError, statestyle.get, i) for i in self.bad_names]
-    
+        for i in self.good_names:
+            statestyle.get(i)
+        for i in self.bad_names:
+            self.assertRaises(ValueError, statestyle.get, i)
+
     def test_fips(self):
-        [statestyle.get(i) for i in self.good_fips]
-        [self.assertRaises(ValueError, statestyle.get, i) for i in self.bad_fips]
-    
+        for i in self.good_fips:
+            statestyle.get(i)
+        for i in self.bad_fips:
+            self.assertRaises(ValueError, statestyle.get, i)
+
     def test_ap(self):
-        [statestyle.get(i) for i in self.good_ap]
-        [self.assertRaises(ValueError, statestyle.get, i) for i in self.bad_ap]
+        for i in self.good_ap:
+            statestyle.get(i)
+        for i in self.bad_ap:
+            self.assertRaises(ValueError, statestyle.get, i)
 
 
 if __name__ == '__main__':

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py25,py26,py27
+envlist=py25,py26,py27,py31,py32,py33
 
 [testenv]
 commands=python test.py

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,5 @@
+[tox]
+envlist=py25,py26,py27
+
+[testenv]
+commands=python test.py


### PR DESCRIPTION
Most notably I made a few changes that allow this library to run on Python 3. To support testing these changes, I added a tox.ini file.

I've also added some Trove classifier tags to the setup.py, though I'm less sure that these are comprehensive. Still, I wanted to note which versions of Python we've tested against.
